### PR TITLE
Allow newer versions of Nautobot.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ license = "LICENSE.txt"
 
 [tool.poetry.dependencies]
 python = "^3.6"
-nautobot = "1.1.0"
+nautobot = "^1.1.0"
 mysqlclient = "^2.0.3"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
With Nautobot 1.1.1 and 1.1.2 this pyproject.toml locks the version of Nautobot to 1.1.0.  I suggest allowing updates to at least minor revisions.