### PR TITLE
Update local dev environment & add sample dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,30 @@
 # Nautobot + Dolt
 
 This is a work in progress and NOT officially released or supported.
+
+## Local Dev & Test Environment
+
+A local environment based on Docker Compose is available for development and testing as well as a sample dataset to help get started faster with Nautobot & Dolt integration.
+
+### Start the Local environment with a sample database
+```
+invoke build
+invoke migrate
+invoke load-data
+```
+Run the following commands to Reset the Local environment and load the sample dataset again
+```
+invoke build
+invoke destroy
+invoke migrate
+invoke load-data
+```
+### Start the Local environment with an empty database
+```
+invoke migrate
+invoke createsuperuser
+invoke start
+```
+
+
+

--- a/README.md
+++ b/README.md
@@ -11,13 +11,19 @@ A local environment based on Docker Compose is available for development and tes
 invoke build
 invoke migrate
 invoke load-data
+invoke start
 ```
+
+> `invoke load-data` can take up to 30 min to run and it will generate many Warning messages, these messages can be ignored.
+
 Run the following commands to Reset the Local environment and load the sample dataset again
 ```
+invoke stop
 invoke build
 invoke destroy
 invoke migrate
 invoke load-data
+invoke start
 ```
 ### Start the Local environment with an empty database
 ```

--- a/development/docker-compose.dev.yml
+++ b/development/docker-compose.dev.yml
@@ -6,11 +6,15 @@
 version: "3.4"
 services:
   nautobot:
+    environment:
+      DATABASE_ROUTERS: "dolt.routers.GlobalStateRouter"
     command: "nautobot-server runserver 0.0.0.0:8080"
     volumes:
       - "./nautobot_config.py:/opt/nautobot/nautobot_config.py"
       - "../:/source"
   worker:
+    environment:
+      DATABASE_ROUTERS: "dolt.routers.GlobalStateRouter"
     volumes:
       - "./nautobot_config.py:/opt/nautobot/nautobot_config.py"
       - "../:/source"

--- a/development/docker-compose.migrate.yml
+++ b/development/docker-compose.migrate.yml
@@ -1,0 +1,15 @@
+# We can't remove volumes in a compose override, for the test configuration using the final containers
+# we don't want the volumes so this is the default override file to add the volumes in the dev case
+# any override will need to include these volumes to use them.
+# see:  https://github.com/docker/compose/issues/3729
+---
+version: "3.4"
+services:
+  nautobot:
+    volumes:
+      - "./nautobot_config.py:/opt/nautobot/nautobot_config.py"
+      - "../:/source"
+  worker:
+    volumes:
+      - "./nautobot_config.py:/opt/nautobot/nautobot_config.py"
+      - "../:/source"

--- a/development/nautobot_config.py
+++ b/development/nautobot_config.py
@@ -258,10 +258,9 @@ PLUGINS = [
     "dolt",
 ]
 
-DATABASE_ROUTERS = [
-    # TODO: currently this breaks migrations
-    # "dolt.routers.GlobalStateRouter",
-]
+# Pull the list of routers from environment variable to be able to disable all routers when we are running the migrations
+routers = os.getenv("DATABASE_ROUTERS", "").split(",")
+DATABASE_ROUTERS = routers if routers != [""] else []
 
 # Plugins configuration settings. These settings are used by various plugins that the user may have installed.
 # Each key in the dictionary is the name of an installed plugin and its value is a dictionary of settings.

--- a/dolt/management/commands/cleanup_data.py
+++ b/dolt/management/commands/cleanup_data.py
@@ -1,0 +1,15 @@
+from django.core.management.base import BaseCommand
+from django.contrib.auth.models import User, Permission
+from django.contrib.contenttypes.models import ContentType
+
+from nautobot.extras.models import Status
+
+class Command(BaseCommand):
+    """Cleanup Database after migrations."""
+
+    help = "Cleanup Database after migrations."
+
+    def handle(self, *args, **kwargs):
+        Status.objects.all().delete()
+        ContentType.objects.all().delete()
+        Permission.objects.all().delete()


### PR DESCRIPTION
Fixes #56 

This PR introduces a new docker-compose file for `invoke migrate` in order to fix an issue when running the migrations when the global router is enable. 
Now the dev environment your work properly as long as we run the migration separately before running `start/debug`

```
invoke migrate
invoke start
```

The PR also includes a sample dataset to allow everyone to test Dolt more easily and a set of commands to load it.
```
invoke destroy
invoke migrate
invoke load-data
invoke start
```