### PR TITLE
Update pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ include = [
 
 [tool.poetry.dependencies]
 python = "^3.6.2"
-nautobot = "~1.2.4"
+nautobot = ">1.2.4"
 # MySQL database adapter
 mysqlclient = "^2.0.3"
 


### PR DESCRIPTION
With the previous value the installation of the plugin meant a degraded version of nautobot being installed, even if you have a later version.

With the change we will be able to use a later version of nautobot without any downgrade problems.