### PR TITLE
Get linters and unit tests passing as a baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,8 +82,8 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ["3.8"]
-        nautobot-version: ["1.5.3"]
+        python-version: ["3.11"]
+        nautobot-version: ["2.0.3"]
     env:
       INVOKE_NAUTOBOT_VERSION_CONTROL_PYTHON_VER: "${{ matrix.python-version }}"
       INVOKE_NAUTOBOT_VERSION_CONTROL_NAUTOBOT_VER: "${{ matrix.nautobot-version }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,15 +119,13 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
         nautobot-version: ["stable"]
         include:
-          - python-version: "3.10"
-            nautobot-version: "1.5.3"
-          - python-version: "3.7"
-            nautobot-version: "1.5.3"
-          - python-version: "3.10"
-            nautobot-version: "stable"
+          - python-version: "3.11"
+            nautobot-version: "2.0.3"
+          - python-version: "3.8"
+            nautobot-version: "2.0.3"
     runs-on: "ubuntu-20.04"
     env:
       INVOKE_NAUTOBOT_VERSION_CONTROL_PYTHON_VER: "${{ matrix.python-version }}"

--- a/.gitignore
+++ b/.gitignore
@@ -298,6 +298,7 @@ fabric.properties
 # Rando
 creds.env
 development/*.txt
+nautobot_version_control/static/nautobot_version_control/docs
 
 # Invoke overrides
 invoke.yml

--- a/development/docker-compose.base.yml
+++ b/development/docker-compose.base.yml
@@ -13,7 +13,6 @@ x-nautobot-base: &nautobot-base
     - "creds.env"
   tty: true
 
-version: "3.8"
 services:
   nautobot:
     depends_on:

--- a/development/docker-compose.dev.yml
+++ b/development/docker-compose.dev.yml
@@ -3,7 +3,6 @@
 # any override will need to include these volumes to use them.
 # see:  https://github.com/docker/compose/issues/3729
 ---
-version: "3.8"
 services:
   nautobot:
     command: "nautobot-server runserver 0.0.0.0:8080"

--- a/development/docker-compose.dev.yml
+++ b/development/docker-compose.dev.yml
@@ -11,29 +11,26 @@ services:
     volumes:
       - "./nautobot_config.py:/opt/nautobot/nautobot_config.py"
       - "../:/source"
-  # TODO: Re-enable
-  # docs:
-  #   entrypoint: "mkdocs serve -v -a 0.0.0.0:8080"
-  #   ports:
-  #     - "8001:8080"
-  #   volumes:
-  #     - "../:/source"
-  #   image: "nautobot-version-control/nautobot:${NAUTOBOT_VER}-py${PYTHON_VER}"
-  #   healthcheck:
-  #     disable: true
-  #   tty: true
-  #worker:
-  #  entrypoint:
-  #    - "sh"
-  #    - "-c"  # this is to evaluate the $NAUTOBOT_LOG_LEVEL from the env
-  #    - "watchmedo auto-restart --directory './' --pattern '*.py' --recursive -- nautobot-server celery worker -l $$NAUTOBOT_LOG_LEVEL --events"  ## $$ because of docker-compose
-  #  volumes:
-  #    - "./nautobot_config.py:/opt/nautobot/nautobot_config.py"
-  #    - "../:/source"
-# To expose postgres or redis to the host uncomment the following
-# postgres:
+# TODO: Re-enable
+# docs:
+#   entrypoint: "mkdocs serve -v -a 0.0.0.0:8080"
 #   ports:
-#     - "5432:5432"
+#     - "8001:8080"
+#   volumes:
+#     - "../:/source"
+#   image: "nautobot-version-control/nautobot:${NAUTOBOT_VER}-py${PYTHON_VER}"
+#   healthcheck:
+#     disable: true
+#   tty: true
+# worker:
+#   entrypoint:
+#     - "sh"
+#     - "-c"  # this is to evaluate the $NAUTOBOT_LOG_LEVEL from the env
+#     - "watchmedo auto-restart --directory './' --pattern '*.py' --recursive -- nautobot-server celery worker -l $$NAUTOBOT_LOG_LEVEL --events"  ## $$ because of docker-compose
+#   volumes:
+#     - "./nautobot_config.py:/opt/nautobot/nautobot_config.py"
+#     - "../:/source"
+# To expose redis to the host uncomment the following
 # redis:
 #   ports:
 #     - "6379:6379"

--- a/development/docker-compose.dolt.yml
+++ b/development/docker-compose.dolt.yml
@@ -1,6 +1,4 @@
 ---
-version: "3.8"
-
 services:
   nautobot:
     environment:

--- a/development/docker-compose.redis.yml
+++ b/development/docker-compose.redis.yml
@@ -1,5 +1,4 @@
 ---
-version: "3.8"
 services:
   redis:
     image: "redis:6-alpine"

--- a/docs/dev/code_reference/diffs.md
+++ b/docs/dev/code_reference/diffs.md
@@ -1,5 +1,0 @@
-# Nautobot Version Control API Package
-
-::: nautobot_version_control.api
-    options:
-        show_submodules: True

--- a/docs/dev/code_reference/index.md
+++ b/docs/dev/code_reference/index.md
@@ -1,6 +1,3 @@
 # Code Reference
 
 Auto-generated code reference documentation from docstrings.
-
-!!! warning "Developer Note - Remove Me!"
-    Uses [mkdocstrings](https://mkdocstrings.github.io/) syntax to auto-generate code documentation from docstrings. Two example pages are provided ([api](api.md) and [package](package.md)), add new stubs for each module or package that you think has relevant documentation.

--- a/docs/user/app_getting_started.md
+++ b/docs/user/app_getting_started.md
@@ -9,7 +9,7 @@ To install the App, please follow the instructions detailed in the [Installation
 ## What are the common operations?
 
 This section describes common Git-like operations that the Version Control app enables on the Nautobot database.
-It is recommended to read these prior to reading the [common workflows](workflows/common_workflows.md) section.
+It is recommended to read these prior to reading the [use cases](app_use_cases.md) section.
 
 ### Branches  
 

--- a/docs/user/app_use_cases.md
+++ b/docs/user/app_use_cases.md
@@ -1,6 +1,6 @@
 # Using the App
 
-This section covers some common workflows. It is recommended to review the [getting started](../app_getting_started.md) section prior to this section.
+This section covers some common workflows. It is recommended to review the [getting started](app_getting_started.md) section prior to this section.
 
 ## Proposing Data Changes
 
@@ -71,9 +71,9 @@ The example below shows that the `bkk-leaf-08` status changed from `Active` to `
 
 ### Viewing Branch Commits
 
-To view commits in a given branch, [activate the branch](../version-control-operations.md#switching-branches) with the commits you are interested in. 
+To view commits in a given branch, [activate the branch](app_getting_started.md#switching-branches) with the commits you are interested in. 
 
-See the [Commits documentation](../version-control-operations.md#commits) to learn how to view commits in the selected branch. 
+See the [Commits documentation](app_getting_started.md#commits) to learn how to view commits in the selected branch. 
 
 ## The Pull Request (PR) Process
 
@@ -91,7 +91,7 @@ Once on the *Add a new pull request* screen, fill out the requested details and 
 
 ### The Pull Request (PR) Detail View
 
-Creating the PR will take you to the PR detail page, which has 4 tabs, [explained here](../version-control-operations.md#pull-request-view).
+Creating the PR will take you to the PR detail page, which has 4 tabs, [explained here](app_getting_started.md#pull-request-view).
 
 ### Reviewing a PR 
 
@@ -102,7 +102,7 @@ To review a PR, go to *Version Control --> Pull Requests*.
 This will take you to the pull requests list page; once there:
 
 * Determine which PR you want to review and its source branch
-* [Switch the active branch](../version-control-operations.md#switching-branches) to that of the PR source branch (this is necessary if you wish to revert any changes in the PR)
+* [Switch the active branch](app_getting_started.md#switching-branches) to that of the PR source branch (this is necessary if you wish to revert any changes in the PR)
 * Navigate back to the PR list page and click on the desired PR
 
 ![](../images/pr-list-page.png)
@@ -114,7 +114,7 @@ Here, you can start a conversation around the PR, including any questions or com
 
 Each review can be a *Comment*, *Approval*, or *Blocked* operation. 
 Once the PR is moved to *Approved* status, a *Merge* button appears, allowing the reviewer to merge the changes into the destination branch.
-For more information on merges, see version control operations [section on merges](../version-control-operations.md#merges).
+For more information on merges, see version control operations [section on merges](app_getting_started.md#merges).
 
 ![](../images/pr-review-conversation.png)
 
@@ -135,10 +135,10 @@ Should a conflict come up, you can do the following:
 
 ![](../images/view-conflict.png)
 
-At this point you can either [revert the specific commit](../version-control-operations.md#reverting-a-commit) in your PR or modify the other branch with the conflict (the `main` branch in this example).
+At this point you can either [revert the specific commit](app_getting_started.md#reverting-a-commit) in your PR or modify the other branch with the conflict (the `main` branch in this example).
 
 
 ## Reverting Commits
 
 At any point during the process of making changes in a branch, reviewing a PR for the changes in a branch, or trying to revert changes already in the main (production) branch, you may want to revert specific commits or revert commits en masse. 
-View how to revert commits [here](../version-control-operations.md#reverting-a-commit).
+View how to revert commits [here](app_getting_started.md#reverting-a-commit).

--- a/nautobot_version_control/__init__.py
+++ b/nautobot_version_control/__init__.py
@@ -1,11 +1,13 @@
 """Plugin declaration for nautobot_version_control."""
+
 # Metadata is inherited from Nautobot. If not including Nautobot in the environment, this should be added
+from importlib import metadata
+
 from django.db.models.signals import pre_migrate, post_migrate
 import django_tables2
 from nautobot.extras.plugins import PluginConfig
 from nautobot_version_control.migrations import auto_dolt_commit_migration
 
-from importlib import metadata
 
 __version__ = metadata.version(__name__)
 

--- a/nautobot_version_control/api/serializers.py
+++ b/nautobot_version_control/api/serializers.py
@@ -1,4 +1,5 @@
 """Serializers for version_control app."""
+
 from rest_framework import serializers
 from nautobot_version_control.models import Branch, Commit, PullRequest, PullRequestReview
 

--- a/nautobot_version_control/filters.py
+++ b/nautobot_version_control/filters.py
@@ -29,7 +29,7 @@ class BranchFilterSet(BaseFilterSet):
         )
         exclude = ("id",)
 
-    def search(self, queryset, name, value):  # pylint: disable=unused-argument,no-self-use
+    def search(self, queryset, name, value):  # pylint: disable=unused-argument
         """
         Search performs an ORM filter on the Branch model.
 
@@ -72,7 +72,7 @@ class CommitFilterSet(BaseFilterSet):
         )
         exclude = ("id",)
 
-    def search(self, queryset, name, value):  # pylint: disable=unused-argument,no-self-use
+    def search(self, queryset, name, value):  # pylint: disable=unused-argument
         """
         Search performs an ORM filter on the Commit model.
 
@@ -115,7 +115,7 @@ class PullRequestFilterSet(BaseFilterSet):
         )
         exclude = ("id",)
 
-    def search(self, queryset, name, value):  # pylint: disable=unused-argument,no-self-use
+    def search(self, queryset, name, value):  # pylint: disable=unused-argument
         """
         Search performs an ORM filter on the PullRequestFilterSet model.
 
@@ -165,7 +165,7 @@ class PullRequestReviewFilterSet(BaseFilterSet):
         )
         exclude = ("id",)
 
-    def search(self, queryset, name, value):  # pylint: disable=unused-argument,no-self-use
+    def search(self, queryset, name, value):  # pylint: disable=unused-argument
         """
         Search performs an ORM filter on the PullRequestReviewFilterSet model.
 

--- a/nautobot_version_control/middleware.py
+++ b/nautobot_version_control/middleware.py
@@ -40,7 +40,7 @@ class DoltBranchMiddleware:
         """Override __call__."""
         return self.get_response(request)
 
-    def process_view(self, request, view_func, view_args, view_kwargs):  # pylint: disable=R0201
+    def process_view(self, request, view_func, view_args, view_kwargs):
         """This maintains the dolt branch session cookie and verifies authentication. It then returns the view that needs to be rendered."""
         # Check whether the desired branch was passed in as a querystring
         query_string_branch = request.GET.get(DOLT_BRANCH_KEYWORD, None)

--- a/nautobot_version_control/migrations/0008_charfield_max_length.py
+++ b/nautobot_version_control/migrations/0008_charfield_max_length.py
@@ -4,25 +4,24 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
-        ('nautobot_version_control', '0007_auto_20210818_1708'),
+        ("nautobot_version_control", "0007_auto_20210818_1708"),
     ]
 
     operations = [
         migrations.AlterField(
-            model_name='branchmeta',
-            name='source_branch',
+            model_name="branchmeta",
+            name="source_branch",
             field=models.CharField(max_length=1024),
         ),
         migrations.AlterField(
-            model_name='pullrequest',
-            name='destination_branch',
+            model_name="pullrequest",
+            name="destination_branch",
             field=models.CharField(max_length=1024),
         ),
         migrations.AlterField(
-            model_name='pullrequest',
-            name='source_branch',
+            model_name="pullrequest",
+            name="source_branch",
             field=models.CharField(max_length=1024),
         ),
     ]

--- a/nautobot_version_control/models.py
+++ b/nautobot_version_control/models.py
@@ -1,6 +1,5 @@
 """Dolt primitives such as branches and commits as Django models."""
 
-
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import models, connection, connections
 from django.db.models import Q
@@ -41,7 +40,7 @@ class DoltSystemTable(models.Model):
 #
 
 
-class Branch(DoltSystemTable):
+class Branch(DoltSystemTable):  # pylint: disable=nb-incorrect-base-class  # TODO
     """Branch represents a model over the dolt_branches system table."""
 
     name = models.TextField(primary_key=True)
@@ -164,7 +163,7 @@ class Branch(DoltSystemTable):
             res = cursor.fetchone()
             # dolt_merge returns a signature that is at the time of this writing:
             # ws, h.String(), noConflictsOrViolations, fastForwardMerge, str, nil
-            # test the noConflictsOrViolations and fastForwardMerge is good 
+            # test the noConflictsOrViolations and fastForwardMerge is good
             if res[1] == 0 and res[2] == 0:  # magic???
                 # only commit merged data on success
                 msg = f"""merged "{merge_branch}" into "{self.name}"."""
@@ -219,10 +218,12 @@ def delete_branch_pre_hook(sender, instance, using, **kwargs):  # pylint: disabl
         pr_list = ",".join([f'"{pr}"' for pr in prs])
         raise DoltError(f"Must delete existing pull request(s): [{pr_list}] before deleting branch {instance.name}")
 
-    raise Exception("QuerySet deletion of Branch is not supported, please delete the items individually")
+    raise Exception(  # pylint: disable=broad-exception-raised  # TODO
+        "QuerySet deletion of Branch is not supported, please delete the items individually"
+    )
 
 
-class BranchMeta(models.Model):
+class BranchMeta(models.Model):  # pylint: disable=nb-incorrect-base-class  # TODO
     """
     BranchMeta class has a 1:1 relation with a Branch.
 
@@ -246,7 +247,7 @@ class BranchMeta(models.Model):
 #
 
 
-class Commit(DoltSystemTable):
+class Commit(DoltSystemTable):  # pylint: disable=nb-incorrect-base-class  # TODO
     """Commit represents a Dolt Commit primitive."""
 
     commit_hash = models.TextField(primary_key=True)
@@ -321,7 +322,7 @@ class Commit(DoltSystemTable):
             )
 
 
-class CommitAncestor(DoltSystemTable):
+class CommitAncestor(DoltSystemTable):  # pylint: disable=nb-incorrect-base-class  # TODO
     """CommitAncestor models the set of ancestors or parents that precede a Commit."""
 
     commit_hash = models.TextField(primary_key=True)
@@ -350,7 +351,7 @@ class CommitAncestor(DoltSystemTable):
 #
 
 
-class Conflicts(DoltSystemTable):
+class Conflicts(DoltSystemTable):  # pylint: disable=nb-incorrect-base-class  # TODO
     """Conflicts represents the dolt_conflicts system table and the conflicts from a merge it contains."""
 
     table = models.TextField(primary_key=True)
@@ -368,7 +369,7 @@ class Conflicts(DoltSystemTable):
         return f"{self.table} ({self.num_conflicts})"
 
 
-class ConstraintViolations(DoltSystemTable):
+class ConstraintViolations(DoltSystemTable):  # pylint: disable=nb-incorrect-base-class  # TODO
     """Foreign Key and Unique Key Constraint Violations."""
 
     table = models.TextField(primary_key=True)
@@ -411,7 +412,7 @@ class PullRequest(BaseModel):
     # can't create Foreign Key to dolt_branches table :(
     source_branch = models.CharField(max_length=1024)
     destination_branch = models.CharField(max_length=1024)
-    description = models.TextField(blank=True, null=True)
+    description = models.TextField(blank=True, null=True)  # pylint: disable=nb-string-field-blank-null  # TODO
     creator = models.ForeignKey(User, on_delete=CASCADE)
     created_at = models.DateTimeField(auto_now_add=True, blank=True, null=True)
 
@@ -428,7 +429,7 @@ class PullRequest(BaseModel):
         """Return a simple string if model is called."""
         return self.title
 
-    def get_absolute_url(self):
+    def get_absolute_url(self):  # pylint: disable=arguments-differ  # TODO
         """Returns a url to render a view of the pull request."""
         return reverse("plugins:nautobot_version_control:pull_request", args=[self.id])
 
@@ -524,7 +525,7 @@ class PullRequestReview(BaseModel):
     reviewer = models.ForeignKey(User, on_delete=CASCADE)
     reviewed_at = models.DateTimeField(auto_now_add=True, blank=True, null=True)
     state = models.IntegerField(choices=REVIEW_STATE_CHOICES, null=True)
-    summary = models.TextField(blank=True, null=True)
+    summary = models.TextField(blank=True, null=True)  # pylint: disable=nb-string-field-blank-null  # TODO
 
     class Meta:
         """Meta information for PullRequestReview model."""
@@ -537,6 +538,6 @@ class PullRequestReview(BaseModel):
         """Return a simple string if model is called."""
         return f""""{self.pull_request}" reviewed by {self.reviewer}"""
 
-    def get_absolute_url(self):
+    def get_absolute_url(self):  # pylint: disable=arguments-differ  # TODO
         """Returns a link to a view of a pull request review."""
         return reverse("plugins:nautobot_version_control:pull_request", args=[self.pull_request.id])

--- a/nautobot_version_control/navigation.py
+++ b/nautobot_version_control/navigation.py
@@ -1,6 +1,5 @@
 """Navigation items for the top level nav bar."""
 
-
 from nautobot.core.apps import NavMenuAddButton, NavMenuGroup, NavMenuItem, NavMenuTab
 
 menu_items = (

--- a/nautobot_version_control/routers.py
+++ b/nautobot_version_control/routers.py
@@ -59,8 +59,8 @@ class GlobalStateRouter:
 
         return self.global_db
 
-    def allow_relation(self, obj1, obj2, **hints):  # pylint: disable=W0613.R0201
-        """Allow a relation between obj1 and obj2 too exist."""
+    def allow_relation(self, obj1, obj2, **hints):  # pylint: disable=W0613  # TODO
+        """Allow a relation between obj1 and obj2 to exist."""
         return True
 
     @staticmethod

--- a/nautobot_version_control/tables.py
+++ b/nautobot_version_control/tables.py
@@ -1,4 +1,5 @@
 """Django Tables2 classes for version_control plugin."""
+
 # pylint: disable=too-few-public-methods
 
 import django_tables2 as tables

--- a/nautobot_version_control/tests/test_doltapi.py
+++ b/nautobot_version_control/tests/test_doltapi.py
@@ -1,4 +1,5 @@
 """tests.py contains unittests for the nautobot version control plugin."""
+
 # pylint: disable=too-many-ancestors
 
 from django.test import override_settings, TransactionTestCase

--- a/nautobot_version_control/tests/test_doltapi.py
+++ b/nautobot_version_control/tests/test_doltapi.py
@@ -113,7 +113,7 @@ class TestBranches(DoltTestCase):
         # Checkout to the other branch and make a change
         other.checkout()
         Manufacturer.objects.all().delete()
-        Manufacturer.objects.create(name="m1", slug="m-1")
+        Manufacturer.objects.create(name="m1")
         Commit(message="added a manufacturer").save(user=self.user_no_email)
 
         commit = Commit.objects.order_by("date").last()
@@ -128,7 +128,7 @@ class TestBranches(DoltTestCase):
             self.assertFalse(cursor.fetchone()[0] is None)
 
         # Verify the the main branch has the data
-        self.assertEqual(Manufacturer.objects.filter(name="m1", slug="m-1").count(), 1)
+        self.assertEqual(Manufacturer.objects.filter(name="m1").count(), 1)
 
     def test_merge_no_ff(self):
         """test_merge_no_ff tests whether a non-ff merge works."""
@@ -137,12 +137,12 @@ class TestBranches(DoltTestCase):
         other = Branch.objects.get(name="noff")
 
         # # Create a change on main
-        Manufacturer.objects.create(name="m2", slug="m-2")
+        Manufacturer.objects.create(name="m2")
         Commit(message="commit m2").save(user=self.user)
 
         # Checkout to the other branch and make a change
         other.checkout()
-        Manufacturer.objects.create(name="m3", slug="m-3")
+        Manufacturer.objects.create(name="m3")
         Commit(message="commit m3").save(user=self.user_no_email)
 
         # Now do a merge
@@ -153,27 +153,27 @@ class TestBranches(DoltTestCase):
             self.assertFalse(cursor.fetchone()[0] is None)
 
         # Verify the the main branch has the data
-        self.assertEqual(Manufacturer.objects.filter(name="m2", slug="m-2").count(), 1)
-        self.assertEqual(Manufacturer.objects.filter(name="m3", slug="m-3").count(), 1)
+        self.assertEqual(Manufacturer.objects.filter(name="m2").count(), 1)
+        self.assertEqual(Manufacturer.objects.filter(name="m3").count(), 1)
 
     def test_merge_conflicts(self):
         """test_merge_conflicts tests whether a merge with conflicts is detected and errors."""
         main = Branch.objects.get(name=self.default)
         Manufacturer.objects.all().delete()
-        Manufacturer.objects.create(name="m2", slug="m-2")
-        Commit(message="commit m2 with slug m-2").save(user=self.user)
+        Manufacturer.objects.create(name="m2", description="m-2")
+        Commit(message="commit m2 with description m-2").save(user=self.user)
 
         Branch(name="conflicts", starting_branch=self.default).save()
         other = Branch.objects.get(name="conflicts")
 
         # # Create a change on main
-        Manufacturer.objects.filter(name="m2", slug="m-2").update(slug="m-15")
-        Commit(message="commit m2 with slug m-15").save(user=self.user)
+        Manufacturer.objects.filter(name="m2").update(description="m-15")
+        Commit(message="commit m2 with description m-15").save(user=self.user)
 
         # Checkout to the other branch and make a change
         other.checkout()
-        Manufacturer.objects.filter(name="m2", slug="m-2").update(slug="m-16")
-        Commit(message="commit m2 with slug m-16").save(user=self.user)
+        Manufacturer.objects.filter(name="m2").update(description="m-16")
+        Commit(message="commit m2 with description m-16").save(user=self.user)
 
         # Now do a merge. It should throw an exception due to conflicts
         main.checkout()

--- a/nautobot_version_control/tests/test_doltapi.py
+++ b/nautobot_version_control/tests/test_doltapi.py
@@ -54,6 +54,8 @@ class TestBranches(DoltTestCase):
 
     def tearDown(self):
         """tearDown is ran after every testcase."""
+        main = Branch.objects.get(name=self.default)
+        main.checkout()
         # Branch QuerySet deletes are not supported, delete branches individually.
         for branch in Branch.objects.exclude(name=self.default):
             branch.delete()

--- a/nautobot_version_control/urls.py
+++ b/nautobot_version_control/urls.py
@@ -1,6 +1,5 @@
 """Routing for the Nautobot Version Control plugin."""
 
-
 from django.urls import path
 
 from nautobot_version_control import views

--- a/nautobot_version_control/utils.py
+++ b/nautobot_version_control/utils.py
@@ -1,6 +1,5 @@
 """Utility methods used throughout the plugin."""
 
-
 from contextlib import contextmanager
 from copy import deepcopy
 
@@ -53,7 +52,7 @@ def db_for_commit(commit):
     """Uses "database-revision" syntax adds a database entry for the commit e.g. "nautobot/3a5mqdgao8029bf8ji0huobbskq1n1l5"."""
     cm_hash = str(commit)
     if len(cm_hash) != 32:
-        raise Exception("commit hash length is incorrect")
+        raise Exception("commit hash length is incorrect")  # pylint: disable=broad-exception-raised  # TODO
     database = deepcopy(connections.databases["default"])
     database["id"] = cm_hash
     database["NAME"] = f"{DB_NAME}/{cm_hash}"

--- a/nautobot_version_control/utils.py
+++ b/nautobot_version_control/utils.py
@@ -20,7 +20,7 @@ def author_from_user(user):
 
     Note that while user.email is optional in Django, it's mandatory for Dolt.
     """
-    if user:
+    if user and user.is_authenticated:
         if user.email:
             return f"{user.username} <{user.email}>"
         # RFC 6761 defines .invalid as a reserved TLD that will never be used for real-world domains

--- a/nautobot_version_control/views.py
+++ b/nautobot_version_control/views.py
@@ -49,7 +49,9 @@ class DoltObjectView(generic.ObjectView):
         # TODO: similar functionality probably needed in NautobotUIViewSet as well, not currently present
         if request.GET.get("viewconfig", None) == "true":
             # TODO: we shouldn't be importing a private-named function from another module. Should it be renamed?
-            from nautobot.extras.templatetags.plugins import _get_registered_content
+            from nautobot.extras.templatetags.plugins import (  # pylint: disable=import-outside-toplevel  # TODO
+                _get_registered_content,
+            )
 
             temp_fake_context = {
                 "object": instance,
@@ -62,19 +64,19 @@ class DoltObjectView(generic.ObjectView):
             plugin_tabs = _get_registered_content(instance, "detail_tabs", temp_fake_context, return_html=False)
             resp = {"tabs": plugin_tabs}
             return JsonResponse(resp)
-        else:
-            return render(
-                request,
-                self.get_template_name(),
-                {
-                    "object": instance,
-                    "verbose_name": self.queryset.model._meta.verbose_name,
-                    "verbose_name_plural": self.queryset.model._meta.verbose_name_plural,
-                    "created_by": created_by,
-                    "last_updated_by": last_updated_by,
-                    **self.get_extra_context(request, instance),
-                },
-            )
+
+        return render(
+            request,
+            self.get_template_name(),
+            {
+                "object": instance,
+                "verbose_name": self.queryset.model._meta.verbose_name,
+                "verbose_name_plural": self.queryset.model._meta.verbose_name_plural,
+                "created_by": created_by,
+                "last_updated_by": last_updated_by,
+                **self.get_extra_context(request, instance),
+            },
+        )
 
 
 #
@@ -315,7 +317,7 @@ class BranchMergePreView(GetReturnURLMixin, View):
         alter_session_branch(sess=request.session, branch=dest)
         return redirect("/")
 
-    def get_extra_context(self, request, src, dest):  # pylint: disable=W0613,C0116,R0201 # noqa: D102
+    def get_extra_context(self, request, src, dest):  # pylint: disable=W0613,C0116 # noqa: D102
         merge_base_c = Commit.merge_base(src, dest)
         source_head = src.hash
         return {
@@ -457,11 +459,11 @@ class CommitRevertView(GetReturnURLMixin, ObjectPermissionRequiredMixin, View):
                         mark_safe(f"""Error reverting commits {", ".join(msgs)}: {err}"""),
                     )
                     return redirect(self.get_return_url(request))
-                else:
-                    messages.success(
-                        request,
-                        mark_safe(f"""Successfully reverted commits {", ".join(msgs)}"""),
-                    )
+
+                messages.success(
+                    request,
+                    mark_safe(f"""Successfully reverted commits {", ".join(msgs)}"""),
+                )
 
         return redirect(self.get_return_url(request))
 
@@ -490,7 +492,7 @@ class DiffDetailView(View):
 
     template_name = "nautobot_version_control/diff_detail.html"
 
-    def get_required_permission(self):  # pylint: disable=R0201
+    def get_required_permission(self):
         """Returns permissions."""
         return get_permission_for_model(Location, "view")  # TODO: what is this doing?
 
@@ -508,7 +510,7 @@ class DiffDetailView(View):
             },
         )
 
-    def get_model(self, kwargs):  # pylint: disable=no-self-use
+    def get_model(self, kwargs):
         """Returns the underlying model."""
         return ContentType.objects.get(app_label=kwargs["app_label"], model=kwargs["model"]).model_class()
 

--- a/tasks.py
+++ b/tasks.py
@@ -630,7 +630,7 @@ def check_migrations(context):
 )
 def unittest(
     context,
-    keepdb=False,
+    keepdb=True,
     label="nautobot_version_control",
     failfast=False,
     buffer=True,
@@ -651,6 +651,9 @@ def unittest(
     if verbose:
         command += " --verbosity 2"
 
+    if not keepdb:
+        raise RuntimeError("The nautobot-version-control unittests require the --keepdb flag to function properly.")
+
     run_command(context, command)
 
 
@@ -669,7 +672,7 @@ def unittest_coverage(context):
         "lint-only": "Only run linters; unit tests will be excluded. (default: False)",
     }
 )
-def tests(context, failfast=False, keepdb=False, lint_only=False):
+def tests(context, failfast=False, keepdb=True, lint_only=False):
     """Run all tests for this app."""
     # If we are not running locally, start the docker containers so we don't have to for each test
     if not is_truthy(context.nautobot_version_control.local):

--- a/tasks.py
+++ b/tasks.py
@@ -46,7 +46,7 @@ namespace = Collection("nautobot_version_control")
 namespace.configure(
     {
         "nautobot_version_control": {
-            "nautobot_ver": "2.0.3",
+            "nautobot_ver": "2.0.6",
             "project_name": "nautobot-version-control",
             "python_ver": "3.11",
             "local": False,
@@ -54,7 +54,7 @@ namespace.configure(
             "compose_files": [
                 "docker-compose.base.yml",
                 "docker-compose.redis.yml",
-                "docker-compose.dolt-hosted.yml",
+                # "docker-compose.dolt-hosted.yml",
                 "docker-compose.dolt.yml",
                 "docker-compose.dev.yml",
             ],


### PR DESCRIPTION
- Add `.gitignore` for compiled docs files
- Remove deprecated `version` keyword from docker-compose files
- Fix bad links in docs
- Black, pylint, yamllint fixes
- Don't try to run dolt both locally and as a hosted service by default.